### PR TITLE
Add branded email templates matching Wonder Cabinet brand guidelines

### DIFF
--- a/assets/email/autoresponder.html
+++ b/assets/email/autoresponder.html
@@ -1,0 +1,96 @@
+<div>
+<div class="body" style="width: 100%; margin: 0 auto !important; padding: 0 !important; mso-line-height-rule: exactly; background-color: #000000;">
+<table class="email-container body-bg" style="width: 720px; text-align: center;" border="0" width="720" cellspacing="0" cellpadding="0" align="center" bgcolor="#000000">
+<tbody>
+<tr>
+<td height="36">&nbsp;</td>
+</tr>
+<tr>
+<td class="mobile-padding-fix" style="padding: 0 40px;" align="center">
+<table style="width: 100%;" border="0" width="100%" cellspacing="0" cellpadding="0" bgcolor="#FFFAEB">
+<tbody>
+<tr>
+<td style="line-height: 0; font-size: 0; border-radius: 4px 4px 0 0;" colspan="3" bgcolor="#10A544" height="8">&nbsp;</td>
+</tr>
+<tr>
+<td width="36">&nbsp;</td>
+<td>
+<table style="width: 100%; border-bottom: 1px solid #043013;" border="0" width="100%" cellspacing="0" cellpadding="0" bgcolor="#FFFAEB">
+<tbody>
+<tr>
+<td style="line-height: 0; font-size: 0;" colspan="3" height="16">&nbsp;</td>
+</tr>
+<tr>
+<td align="left" valign="top" width="40"><img src="https://www.jotform.com/uploads/Wonder_Cabinet/form_files/Channel_Icon-WonderCabinetProductions.6994a5497f4528.03104971.png" alt="Wonder Cabinet" /></td>
+<td align="left" valign="middle"><strong><span style="font-size: 14pt; font-family: Jost, Futura, 'Trebuchet MS', Arial, sans-serif; color: #043013;">Thanks for reaching out! Here's what we received:</span></strong></td>
+</tr>
+<tr>
+<td style="line-height: 0; font-size: 0;" colspan="3" height="16">&nbsp;</td>
+</tr>
+</tbody>
+</table>
+</td>
+<td width="36">&nbsp;</td>
+</tr>
+</tbody>
+</table>
+<table style="width: 100%; border-radius: 0 0 4px 4px;" border="0" width="100%" cellspacing="0" cellpadding="0" bgcolor="#FFFAEB">
+<tbody>
+<tr>
+<td colspan="3" height="24">&nbsp;</td>
+</tr>
+<tr>
+<td style="min-width: 36px;" width="36">&nbsp;</td>
+<td align="center">
+<table id="emailFieldsTable" class="mceNonEditable" style="font-size: 14px; font-family: 'EB Garamond', Garamond, 'Times New Roman', serif;" border="0" width="100%" cellspacing="0" cellpadding="5">
+<tbody id="emailFieldsTableBody" style="border-radius: 0;">
+<tr class="questionRow">
+<td class="questionColumn" style="padding: 5px !important; color: #000000;" valign="top" bgcolor="#FFFAEB" width="170">&nbsp;</td>
+<td class="valueColumn" style="padding: 5px !important; color: #000000;" bgcolor="#FFFAEB">&nbsp;</td>
+</tr>
+<tr id="row_3" class="questionRow">
+<td id="question_3" class="questionColumn" style="padding: 5px !important; color: #043013; font-family: Jost, Futura, 'Trebuchet MS', Arial, sans-serif; font-weight: bold; font-size: 13px; text-transform: uppercase; letter-spacing: 0.5px;" valign="top" bgcolor="#FFFAEB" width="170">Name</td>
+<td id="value_3" class="valueColumn" style="padding: 5px !important; color: #000000; font-family: 'EB Garamond', Garamond, 'Times New Roman', serif; font-size: 15px;" bgcolor="#FFFAEB">{name}</td>
+</tr>
+<tr id="row_4" class="questionRow">
+<td id="question_4" class="questionColumn" style="padding: 5px !important; color: #043013; font-family: Jost, Futura, 'Trebuchet MS', Arial, sans-serif; font-weight: bold; font-size: 13px; text-transform: uppercase; letter-spacing: 0.5px;" valign="top" bgcolor="#FFFAEB" width="170">Email</td>
+<td id="value_4" class="valueColumn" style="padding: 5px !important; color: #000000; font-family: 'EB Garamond', Garamond, 'Times New Roman', serif; font-size: 15px;" bgcolor="#FFFAEB">{email}</td>
+</tr>
+<tr id="row_9" class="questionRow">
+<td id="question_9" class="questionColumn" style="padding: 5px !important; color: #043013; font-family: Jost, Futura, 'Trebuchet MS', Arial, sans-serif; font-weight: bold; font-size: 13px; text-transform: uppercase; letter-spacing: 0.5px;" valign="top" bgcolor="#FFFAEB" width="170">Why are you reaching out?</td>
+<td id="value_9" class="valueColumn" style="padding: 5px !important; color: #000000; font-family: 'EB Garamond', Garamond, 'Times New Roman', serif; font-size: 15px;" bgcolor="#FFFAEB">{whyAre}</td>
+</tr>
+<tr id="row_7" class="questionRow">
+<td id="question_7" class="questionColumn" style="padding: 5px !important; color: #043013; font-family: Jost, Futura, 'Trebuchet MS', Arial, sans-serif; font-weight: bold; font-size: 13px; text-transform: uppercase; letter-spacing: 0.5px;" valign="top" bgcolor="#FFFAEB" width="170">Message</td>
+<td id="value_7" class="valueColumn" style="padding: 5px !important; color: #000000; font-family: 'EB Garamond', Garamond, 'Times New Roman', serif; font-size: 15px;" bgcolor="#FFFAEB">{message7}</td>
+</tr>
+</tbody>
+</table>
+</td>
+<td style="min-width: 36px;" width="36">&nbsp;</td>
+</tr>
+<tr>
+<td colspan="3" height="24">&nbsp;</td>
+</tr>
+</tbody>
+</table>
+<table id="autoresponder-footer" style="font-family: Jost, Futura, 'Trebuchet MS', Arial, sans-serif;" border="0" width="100%" cellspacing="0" cellpadding="0">
+<tbody>
+<tr>
+<td bgcolor="#000000" height="16">&nbsp;</td>
+<td bgcolor="#000000">&nbsp;</td>
+</tr>
+<tr>
+<td colspan="2" style="text-align: center; padding: 12px 0;" bgcolor="#000000"><span style="color: #FFFAEB; font-size: 13px; font-family: 'EB Garamond', Garamond, 'Times New Roman', serif;">Wonder Cabinet &middot; From the creators of <em>To The Best Of Our Knowledge</em></span></td>
+</tr>
+</tbody>
+</table>
+</td>
+</tr>
+<tr>
+<td height="30">&nbsp;</td>
+</tr>
+</tbody>
+</table>
+</div>
+</div>

--- a/assets/email/notification.html
+++ b/assets/email/notification.html
@@ -1,0 +1,81 @@
+<div>
+<div class="body" style="width: 100%; margin: 0 auto !important; padding: 0 !important; mso-line-height-rule: exactly; background-color: #000000;">
+<table class="email-container body-bg" style="width: 720px; text-align: center;" border="0" width="720" cellspacing="0" cellpadding="0" align="center" bgcolor="#000000">
+<tbody>
+<tr>
+<td height="36">&nbsp;</td>
+</tr>
+<tr>
+<td class="mobile-padding-fix" style="padding: 0 40px;" align="center">
+<table style="width: 100%; border-radius: 4px 4px 0 0;" border="0" width="100%" cellspacing="0" cellpadding="0" bgcolor="#FFFAEB">
+<tbody>
+<tr>
+<td colspan="3" height="24"><img src="https://www.jotform.com/uploads/Wonder_Cabinet/form_files/wondercabinet-newsletter.695dca55a40390.35576693.png" alt="Wonder Cabinet Newsletter" style="max-width: 100%; height: auto; display: block;" /></td>
+</tr>
+<tr>
+<td colspan="3" height="24">&nbsp;</td>
+</tr>
+<tr>
+<td style="min-width: 36px;" width="36">&nbsp;</td>
+<td align="center">
+<table id="emailFieldsTable" class="mceNonEditable" style="font-size: 14px; font-family: 'EB Garamond', Garamond, 'Times New Roman', serif;" border="0" width="100%" cellspacing="0" cellpadding="5">
+<tbody id="emailFieldsTableBody" style="border-radius: 0;">
+<tr id="row_3" class="questionRow">
+<td id="question_3" class="questionColumn" style="padding: 5px !important; border: 1px solid #043013; color: #043013; font-family: Jost, Futura, 'Trebuchet MS', Arial, sans-serif; font-weight: bold; font-size: 13px; text-transform: uppercase; letter-spacing: 0.5px;" valign="top" bgcolor="#FFFAEB" width="170">Name</td>
+<td id="value_3" class="valueColumn" style="padding: 5px !important; border: 1px solid #043013; color: #000000; font-family: 'EB Garamond', Garamond, 'Times New Roman', serif; font-size: 15px;" bgcolor="#FFFAEB">&nbsp;</td>
+</tr>
+<tr id="row_4" class="questionRow">
+<td id="question_4" class="questionColumn" style="padding: 5px !important; border: 1px solid #043013; color: #043013; font-family: Jost, Futura, 'Trebuchet MS', Arial, sans-serif; font-weight: bold; font-size: 13px; text-transform: uppercase; letter-spacing: 0.5px;" valign="top" bgcolor="#FFFAEB" width="170">Email</td>
+<td id="value_4" class="valueColumn" style="padding: 5px !important; border: 1px solid #043013; color: #000000; font-family: 'EB Garamond', Garamond, 'Times New Roman', serif; font-size: 15px;" bgcolor="#FFFAEB">{email}</td>
+</tr>
+<tr id="row_9" class="questionRow">
+<td id="question_9" class="questionColumn" style="padding: 5px !important; border: 1px solid #043013; color: #043013; font-family: Jost, Futura, 'Trebuchet MS', Arial, sans-serif; font-weight: bold; font-size: 13px; text-transform: uppercase; letter-spacing: 0.5px;" valign="top" bgcolor="#FFFAEB" width="170">Why are you reaching out?</td>
+<td id="value_9" class="valueColumn" style="padding: 5px !important; border: 1px solid #043013; color: #000000; font-family: 'EB Garamond', Garamond, 'Times New Roman', serif; font-size: 15px;" bgcolor="#FFFAEB">{whyAre}</td>
+</tr>
+<tr id="row_7" class="questionRow">
+<td id="question_7" class="questionColumn" style="padding: 5px !important; border: 1px solid #043013; color: #043013; font-family: Jost, Futura, 'Trebuchet MS', Arial, sans-serif; font-weight: bold; font-size: 13px; text-transform: uppercase; letter-spacing: 0.5px;" valign="top" bgcolor="#FFFAEB" width="170">Message</td>
+<td id="value_7" class="valueColumn" style="padding: 5px !important; border: 1px solid #043013; color: #000000; font-family: 'EB Garamond', Garamond, 'Times New Roman', serif; font-size: 15px;" bgcolor="#FFFAEB">{message7}</td>
+</tr>
+</tbody>
+</table>
+</td>
+<td style="min-width: 36px;" width="36">&nbsp;</td>
+</tr>
+<tr>
+<td colspan="3" height="24">&nbsp;</td>
+</tr>
+</tbody>
+</table>
+</td>
+</tr>
+<tr>
+<td class="mobile-padding-fix" style="padding: 0 40px;" align="center">
+<table style="font-family: Jost, Futura, 'Trebuchet MS', Arial, sans-serif; border-radius: 0 0 4px 4px;" border="0" width="100%" cellspacing="0" cellpadding="0" bgcolor="#FFFAEB">
+<tbody>
+<tr>
+<td width="36">&nbsp;</td>
+<td style="border-top: 1px solid #043013;" height="20">&nbsp;</td>
+<td width="36">&nbsp;</td>
+</tr>
+<tr class="line-show" style="display: none;">
+<td width="36">&nbsp;</td>
+<td class="forward-text-show" style="display: none; font-size: 13px; text-align: center; color: #043013;">You can <span style="color: #10A544;">{edit_submission}</span> and <span style="color: #10A544;">{all_submissions}</span> easily.</td>
+<td width="36">&nbsp;</td>
+</tr>
+<tr class="line-show" style="display: none;">
+<td colspan="3" height="20">&nbsp;</td>
+</tr>
+</tbody>
+</table>
+</td>
+</tr>
+<tr>
+<td style="text-align: center; padding: 16px 0;" bgcolor="#000000"><span style="color: #FFFAEB; font-size: 13px; font-family: 'EB Garamond', Garamond, 'Times New Roman', serif;">Wonder Cabinet &middot; From the creators of <em>To The Best Of Our Knowledge</em></span></td>
+</tr>
+<tr>
+<td height="30">&nbsp;</td>
+</tr>
+</tbody>
+</table>
+</div>
+</div>


### PR DESCRIPTION
Restyle JotForm autoresponder and notification emails to use brand colors (Black #000000, Green #10A544, Cream #FFFAEB, Dark Green #043013), brand typography (Jost for labels, EB Garamond for body text), and replace generic Jotform footer with Wonder Cabinet branding.

https://claude.ai/code/session_01YEmik89houKiUKCs62oWud