### PR TITLE
fix: CTA shows page title instead of subscribe text on contact page

### DIFF
--- a/custom-contact.hbs
+++ b/custom-contact.hbs
@@ -86,7 +86,7 @@
         </div>
     </section>
 
-    {{> "components/cta"}}
+    {{> "components/cta" title=@custom.email_signup_text}}
 </main>
 {{/post}}
 


### PR DESCRIPTION
## Summary
- The CTA partial on the contact page was displaying "Contact" (the page title) instead of the subscribe message
- This happened because Handlebars partials inherit the parent `{{#post}}` block scope, so `{{title}}` resolved to the page's title
- Fix: explicitly pass `@custom.email_signup_text` to the CTA partial, matching how `home.hbs` already calls it

## Test plan
- [x] Visit `/contact/` — CTA should show the custom subscribe text (or the default fallback), not "Contact"
- [x] Visit homepage — CTA unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)