### PR TITLE
ci: grant @claude workflow contents+pull-requests write

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -19,8 +19,8 @@ jobs:
       (github.event_name == 'issues' && (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')))
     runs-on: ubuntu-latest
     permissions:
-      contents: read
-      pull-requests: read
+      contents: write
+      pull-requests: write
       issues: read
       id-token: write
       actions: read # Required for Claude to read CI results on PRs


### PR DESCRIPTION
Lets the interactive `@claude` workflow push small fixes to a PR branch when asked (was `contents: read`, so it could only comment). The auto-reviewer (`claude-code-review.yml`) stays read-only.

Note: writes to `.claude/**` paths still need an explicit allowlist — the action protects those on untrusted heads.

\U0001F916 Generated with [Claude Code](https://claude.com/claude-code)