### PR TITLE
docs(planning): post-Luminous sprint roadmap + backlog sync

### DIFF
--- a/planning/backlog.md
+++ b/planning/backlog.md
@@ -72,6 +72,37 @@ Technical debt and hygiene — no user-facing impact.
 
 ---
 
+## Post-Luminous maintenance sprints
+
+Open GitHub issues compiled into sequenced sprints to execute **after** the Luminous brand arc lands its combined deploy (PRs #46 + #53). Full sequencing, dependencies, and the disposition of Luminous-resolved/entangled issues live in the roadmap → [`post-luminous-roadmap.md`](post-luminous-roadmap.md). Promote one sprint at a time into `sprints/current/` per [`TRIAGE.md`](TRIAGE.md).
+
+**Gate:** blocked until PRs #46 + #53 merge — that merge also closes #34/#51/#52 (verify-and-close batch in the roadmap).
+
+### Hygiene micro-batch (sub-threshold — one maintenance session)
+
+- [ ] **[2026-07-22]** [S4/hygiene] Delete orphaned `illustration-footer-cabinet-table.png` (only `.svg` referenced) - ([#42](https://github.com/Wonder-Cabinet-Productions/wonder-cabinet-episode/issues/42))
+- [ ] **[2026-07-22]** [S4/hygiene] Delete orphaned favicon/app-icon set (Option A) - ([#41](https://github.com/Wonder-Cabinet-Productions/wonder-cabinet-episode/issues/41))
+- [ ] **[2026-07-22]** [S4/docs] README: document highlight zones + featured-flag content workflow + tag-slug deps - ([#38](https://github.com/Wonder-Cabinet-Productions/wonder-cabinet-episode/issues/38))
+
+### Sprint 4 — Homepage content-density & discovery UX (dependency-ordered)
+
+- [ ] **[2026-07-22]** [S3/hbs] Fix highlight-zone double-render — `home.hbs` feed filter omits `island-of-knowledge` - ([#35](https://github.com/Wonder-Cabinet-Productions/wonder-cabinet-episode/issues/35))
+- [ ] **[2026-07-22]** [S4/feature] Load More Episodes (Content API) — enabler; branch `feature/load-more-episodes` in progress - ([#24](https://github.com/Wonder-Cabinet-Productions/wonder-cabinet-episode/issues/24))
+- [ ] **[2026-07-22]** [S4/enhancement] Content density — split newsletter highlight + 2nd featured box + ~6 episodes - ([#22](https://github.com/Wonder-Cabinet-Productions/wonder-cabinet-episode/issues/22))
+- [ ] **[2026-07-22]** [S4/enhancement] Archive-page experiment — 2-wide + infinite scroll (reuses #24) - ([#23](https://github.com/Wonder-Cabinet-Productions/wonder-cabinet-episode/issues/23))
+- [ ] **[2026-07-22]** [S4/enhancement] Consistent item count between highlight zones (unblocks post-deploy) - ([#39](https://github.com/Wonder-Cabinet-Productions/wonder-cabinet-episode/issues/39))
+
+### Sprint 5 — Component wiring & membership (design-gated, last)
+
+- [ ] **[2026-07-22]** [S4/feature] Wire `bracket-button` into live templates — WC-scoped (Luminous hides brackets) - ([#43](https://github.com/Wonder-Cabinet-Productions/wonder-cabinet-episode/issues/43))
+- [ ] **[2026-07-22]** [S4/feature] Paid-membership upgrade surfaces (navbar/support prompt/Portal) — needs mockups - ([#33](https://github.com/Wonder-Cabinet-Productions/wonder-cabinet-episode/issues/33))
+
+### Owned by the Luminous arc — not re-sprinted (see roadmap)
+
+- #40 residual SVG greens → Luminous Sprint 2.2 · #37 Luminous tag-page spacing → Sprint 2 template variants · #29 `--wc-dark-green` brand decision → Sprint 3 Impeccable audit
+
+---
+
 ## Recommended Execution Order
 
 1. **Accessibility + Mobile audit** — combine into one session (overlapping methodology, same templates/CSS)

--- a/planning/post-luminous-roadmap.md
+++ b/planning/post-luminous-roadmap.md
@@ -1,0 +1,75 @@
+# Post-Luminous Roadmap
+
+**Status**: Planning — not yet started (gated)
+**Gate**: Blocked until the Luminous brand arc lands its combined deploy (PRs [#46](https://github.com/Wonder-Cabinet-Productions/wonder-cabinet-episode/pull/46) + [#53](https://github.com/Wonder-Cabinet-Productions/wonder-cabinet-episode/pull/53))
+**Scope**: Compiles the open GitHub issues into sequenced, ready-to-promote sprints for after Luminous
+**Related**: `docs/multi-brand-design-system.md` §9 (live refactor backlog) · the Luminous umbrella spec + `planning/sprints/1-foundation/` land with the deploy
+
+## Purpose
+
+The Luminous multi-brand work is in flight across two stacked PRs held for a **single combined production deploy**. This roadmap organizes the remaining open issues into a plan we can execute once that deploy lands — grouped by theme, ordered by dependency, and de-conflicted against work the Luminous arc already owns. It is the sequencing authority; [`backlog.md`](backlog.md) carries the same items as tracked entries. Promote one sprint at a time into `planning/sprints/current/` (`design.md` + `features.json`) per [`TRIAGE.md`](TRIAGE.md)'s 3+-related-issues rule.
+
+## Gate
+
+**Nothing here starts until PRs #46 + #53 merge.** That merge is also what closes the resolved issues below (via `Closes` footers) and makes them verifiable on the live site — so the roadmap's first action is a verify-and-close pass, not a sprint.
+
+## Disposition of all 16 open issues
+
+| Bucket | Issues | Action |
+|---|---|---|
+| **Resolved by Luminous** | #34, #51, #52 | Verify-and-close batch (below) — do **not** re-sprint |
+| **Entangled — owned by the Luminous arc** | #40, #37, #29 | Coordinate, don't re-sprint (see "Luminous-arc coordination") |
+| **Genuinely post-Luminous** | #35, #24, #22, #23, #39 · #43, #33 · #42, #41, #38 | The batch + sprints below |
+
+## Verify-and-close batch (run immediately after the combined deploy)
+
+Not a sprint — a short confirmation pass. The fixes live on the held branches; leave the issues open until the deploy makes them live.
+
+- [ ] [#34](https://github.com/Wonder-Cabinet-Productions/wonder-cabinet-episode/issues/34) — Luminous accent colors finalized in PR #46 (`--luminous-accent` → `#9A59FF` + text/dark variants). Confirm the `.wc-highlight--luminous` card/badge/button render violet live, then close.
+- [ ] [#51](https://github.com/Wonder-Cabinet-Productions/wonder-cabinet-episode/issues/51) — focus-ring contrast guardrail; PR #53 commit `a8c8cbb8` carries `Closes #51`. Confirm auto-closed on merge; close manually if not.
+- [ ] [#52](https://github.com/Wonder-Cabinet-Productions/wonder-cabinet-episode/issues/52) — contradictory `.wc-transcript-toggle:focus-visible` pair; same commit carries `Closes #52` (the issue *body* text saying "out of scope" is stale — it was fixed by a later commit on the same branch). Confirm auto-closed.
+- [ ] Spot-check [#40](https://github.com/Wonder-Cabinet-Productions/wonder-cabinet-episode/issues/40) (CSS greens now tokenized to `--show-accent`; SVG greens still open — see coordination) and [#37](https://github.com/Wonder-Cabinet-Productions/wonder-cabinet-episode/issues/37) against the deployed state.
+
+## Hygiene micro-batch — *not a promoted sprint*
+
+Independent, zero-dependency quick wins, below the 3-issue-per-category promotion threshold. Run as a single maintenance session (ideally before Sprint 4).
+
+- [ ] [#42](https://github.com/Wonder-Cabinet-Productions/wonder-cabinet-episode/issues/42) — delete orphaned `assets/images/illustration-footer-cabinet-table.png` (only the `.svg` is referenced live).
+- [ ] [#41](https://github.com/Wonder-Cabinet-Productions/wonder-cabinet-episode/issues/41) — delete the orphaned 6-file favicon/app-icon set (**Option A**; live site uses the logo WebP as Ghost Publication Icon). *Choosing Option A closes #41 and makes its Option B — wiring the icons into `default.hbs`, deferred to Sprint 5 — moot.*
+- [ ] [#38](https://github.com/Wonder-Cabinet-Productions/wonder-cabinet-episode/issues/38) — README: document homepage highlight zones, the Ghost Admin featured-flag content workflow, and the hardcoded tag-slug dependencies in `home.hbs`. Docs-only.
+
+## Sprint 4 — Homepage content-density & discovery UX
+
+> **Category**: `hbs` + `feature`/`enhancement` · **5 issues → qualifies for promotion** · **Order**: first (highest listener-facing value, self-contained).
+
+Dependency-ordered — earlier items unblock later ones:
+
+| # | Issue | Work | Why this order |
+|---|---|---|---|
+| 1 | [#35](https://github.com/Wonder-Cabinet-Productions/wonder-cabinet-episode/issues/35) | Fix highlight-zone double-render: `home.hbs` `{{#get}}` feed filter excludes `newsletter`/`luminous` but **not** `island-of-knowledge`, so IoK episodes appear twice | Foundational — corrects the feed math everything else builds on |
+| 2 | [#24](https://github.com/Wonder-Cabinet-Productions/wonder-cabinet-episode/issues/24) | Load More Episodes (client-side Content API). In-progress branch `feature/load-more-episodes` adds `load-more.js`, edits `home.hbs` + `screen.css` | The enabler mechanism for #23 and #39 |
+| 3 | [#22](https://github.com/Wonder-Cabinet-Productions/wonder-cabinet-episode/issues/22) | Content density: split newsletter highlight into latest-newsletter + a 2nd featured box lower down; extend to ~6 episodes | Builds on corrected feed + load-more |
+| 4 | [#23](https://github.com/Wonder-Cabinet-Productions/wonder-cabinet-episode/issues/23) | Archive-page experiment: 2-wide tag archives + infinite scroll; check perf | Reuses #24's load-more |
+| 5 | [#39](https://github.com/Wonder-Cabinet-Productions/wonder-cabinet-episode/issues/39) | Consistent item count between highlight zones | Was blocked on Luminous content migration — **unblocks automatically post-deploy** |
+
+## Sprint 5 — Component wiring & membership surfaces
+
+> **Category**: `feature`/`css`/`hbs` · **design-first** · **Order**: last — gated on design mockups and the brand kit's icon-only mark.
+
+- [ ] [#43](https://github.com/Wonder-Cabinet-Productions/wonder-cabinet-episode/issues/43) — wire the built `bracket-button` partial + `.wc-bracket-btn` CSS into live templates (`home.hbs`, `cta.hbs`, `list-item.hbs`, `highlight-zone.hbs`, `error.hbs`, `error-404.hbs`). **Coordinate with Luminous Sprint 2.2**, which *hides* bracket ornaments under Luminous — the wiring must stay WC-scoped.
+- [ ] [#33](https://github.com/Wonder-Cabinet-Productions/wonder-cabinet-episode/issues/33) — paid-membership "patronage, not paywall" surfaces (navbar supporter indicator, post-page support prompt, Portal theming). **Needs design mockups before implementation.**
+- [ ] [#41](https://github.com/Wonder-Cabinet-Productions/wonder-cabinet-episode/issues/41) **Option B** — *only if the hygiene batch kept the favicons*: wire the app-icon set into `default.hbs`, gated on the brand kit's icon-only mark. (Default assumption: Option A deleted them and this drops.)
+
+## Luminous-arc coordination — *not re-sprinted here*
+
+These open issues overlap the Luminous arc's own deferred list. They belong to that arc; tracked here only so nobody double-plans them.
+
+- [#40](https://github.com/Wonder-Cabinet-Productions/wonder-cabinet-episode/issues/40) — residual SVG greens (`#00b86c`, `#4ba250` in `illustration-footer-cabinet-table.svg` / `icon-search.svg`). The CSS side is tokenized; SVG fill tokenization is deferred to **Luminous Sprint 2.2** (`multi-brand-design-system.md` §9, backlog #4).
+- [#37](https://github.com/Wonder-Cabinet-Productions/wonder-cabinet-episode/issues/37) — Luminous tag-page podcast-button spacing (`series-info.hbs` vs `podcast-services.hbs`); belongs to **Luminous Sprint 2** "template variants."
+- [#29](https://github.com/Wonder-Cabinet-Productions/wonder-cabinet-episode/issues/29) — `--wc-dark-green` (`#043013`) brand-guide decision. Several consumers were rerouted to `--show-accent-dark` by PR #46 (line numbers in the issue now stale), but the *is-it-on-brand* question is unanswered → fold into **Luminous Sprint 3** (Impeccable audit).
+
+## Numbering & promotion notes
+
+- Sprint numbers **continue the existing line** — the Luminous arc owns 1–3, so these are 4 and 5. Adjust if the arc adds sprints before this lands.
+- Per convention, **do not** scaffold `planning/sprints/4-*` / `5-*` until the sprint is promoted to `current` at execution time; `design.md`'s "What shipped" table is written retrospectively.
+- The hygiene micro-batch is deliberately **not** a promoted sprint (sub-threshold) — clear it in a maintenance session.


### PR DESCRIPTION
## What's in here

Compiles the 16 open issues into a **gated, dependency-ordered plan** to execute once the Luminous brand arc lands its combined deploy (PRs #46 + #53). Planning artifacts only — no theme source touched.

| File | Change |
|---|---|
| `planning/post-luminous-roadmap.md` (new) | The sequencing authority: gate, 3-bucket disposition table, verify-and-close batch, hygiene micro-batch, Sprint 4, Sprint 5, Luminous-arc coordination |
| `planning/backlog.md` | New "Post-Luminous maintenance sprints" section mirroring the plan, with each issue as a tracked entry |

**How the 16 issues sort:**
- **Resolved by Luminous** — #34 (PR #46), #51 + #52 (`Closes` in PR #53) → verify-and-close batch, *not* re-sprinted
- **Entangled — owned by the Luminous arc** — #40 (SVG greens → Sprint 2.2), #37 (→ Sprint 2 template variants), #29 (→ Sprint 3 Impeccable audit) → referenced only
- **Genuinely post-Luminous** →
  - *Hygiene micro-batch* (sub-threshold, one session): #42, #41, #38
  - *Sprint 4 — content-density & discovery* (5 issues): #35 → #24 → #22/#23/#39
  - *Sprint 5 — component + membership* (design-gated, last): #43, #33

## Why off `main`

The Luminous PRs are held for one combined deploy; this roadmap shouldn't be gated behind them, so it branches off `main`. Cross-links to Luminous-branch-only artifacts (umbrella spec, `planning/sprints/1-foundation/`) are forward references that resolve once that deploy lands.

## Verification

- ✅ Every genuinely-post-Luminous issue placed in exactly one batch/sprint; every resolved/entangled issue accounted for in the disposition table
- ✅ Docs-only diff — no `.hbs`/CSS/JS change, so gscan is unaffected
- ✅ Sprints not scaffolded — `planning/sprints/4-*`/`5-*` created only on promotion to `current` per `TRIAGE.md`

## Notes

- Sprint numbers continue the existing line (Luminous owns 1–3).
- Companion hygiene (labeling the 6 previously-unlabeled issues into the taxonomy) is applied directly on the issues, outside this PR.