### PR TITLE
Base guard: block sprint work by content, not branch name

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,26 +36,53 @@ jobs:
     name: Base Branch Guard
     if: github.base_ref == 'main'
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: read
 
     steps:
-      - name: Reject sprint branches targeting main
+      - name: Reject sprint work targeting main
         env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+          PR: ${{ github.event.pull_request.number }}
           HEAD_REF: ${{ github.head_ref }}
           # Escape hatch, evaluated inside the step rather than as a job-level `if`, so the
           # check still reports and cannot deadlock a locked-down main.
           OVERRIDE: ${{ contains(github.event.pull_request.labels.*.name, 'base-guard-override') }}
         run: |
+          RETARGET="Retarget with: gh pr edit $PR --base dev/<series>. See docs/BRANCHING.md. Override with the 'base-guard-override' label."
+
           if [ "$OVERRIDE" = "true" ]; then
             echo "::notice::'base-guard-override' label present — skipping base branch check."
             exit 0
           fi
 
+          # The two sanctioned ways into main. Checked first so a rollup PR never pays for
+          # the file listing below, which can be thousands of files for a whole series.
           case "$HEAD_REF" in
+            dev/*|hotfix/*)
+              echo "'$HEAD_REF' -> main is allowed (series rollup or hotfix)."
+              exit 0
+              ;;
             sprint/*)
-              msg="'$HEAD_REF' targets main. Sprint work merges into the series integration branch (dev/<series>), which then rolls up to main as one gated deploy. Retarget with: gh pr edit <n> --base dev/<series>. See docs/BRANCHING.md. Override with the 'base-guard-override' label."
-              echo "::error::$msg"
+              echo "::error::'$HEAD_REF' targets main. Sprint work merges into the series integration branch (dev/<series>), which then rolls up to main as one gated deploy. $RETARGET"
               exit 1
               ;;
           esac
 
-          echo "'$HEAD_REF' -> main is allowed (series rollup, hotfix, or repo plumbing)."
+          # Branch naming is not a reliable signal — agent worktrees produce names like
+          # 'name-change' or 'worktree/brave-cloud-8ac8' that no pattern anticipates. What
+          # actually distinguishes sprint work from repo plumbing is whether it carries theme
+          # source. Plumbing (docs, planning, CI) never does; a partial series always does.
+          THEME=$(gh api --paginate "repos/$REPO/pulls/$PR/files" --jq '.[].filename' \
+                  | grep -E '^(assets/|partials/)|\.hbs$' || true)
+
+          if [ -n "$THEME" ]; then
+            echo "::error::'$HEAD_REF' targets main and changes theme source, which would deploy a partial series. Land it in dev/<series> so the whole series ships together. $RETARGET"
+            echo "Theme files in this PR:"
+            echo "$THEME" | sed 's/^/  /' | head -30
+            exit 1
+          fi
+
+          echo "'$HEAD_REF' -> main touches no theme source — allowed (repo plumbing)."

--- a/docs/BRANCHING.md
+++ b/docs/BRANCHING.md
@@ -53,10 +53,26 @@ The `dev/**` glob is what CI and the branch-protection ruleset key on. A branch 
 
 ## Which base branch?
 
-**Sprint work targets `dev/<series>`. Never `main`.** This is enforced: a `sprint/*` branch
-opened against `main` fails the **Base Branch Guard** check in CI. The error names the fix
-(`gh pr edit <n> --base dev/<series>`). If you genuinely need the exception, add the
-`base-guard-override` label to the PR and re-run.
+**Sprint work targets `dev/<series>`. Never `main`.** This is enforced by the **Base Branch
+Guard** check, which is required on `main`. Its decision order:
+
+| # | Condition | Result |
+|---|---|---|
+| 1 | PR has the `base-guard-override` label | **pass** |
+| 2 | head is `dev/**` or `hotfix/*` | **pass** — series rollup or hotfix |
+| 3 | head is `sprint/*` | **fail** |
+| 4 | PR changes `assets/`, `partials/`, or any `*.hbs` | **fail** — that's a partial series |
+| 5 | otherwise | **pass** — repo plumbing |
+
+Rule 4 exists because **branch naming is not a reliable signal.** Agent worktrees produce names
+like `name-change` or `worktree/brave-cloud-8ac8` that no pattern anticipates, and a `sprint/*`
+deny-list alone would wave them straight into production. What actually separates sprint work
+from plumbing is whether it carries theme source: plumbing (docs, planning, CI) never does, a
+partial series always does.
+
+The error message names the fix (`gh pr edit <n> --base dev/<series>`). If you genuinely need the
+exception, add the `base-guard-override` label and re-trigger — note that a *re-run* replays the
+original event payload and won't see the new label, so push a commit or reopen the PR instead.
 
 `main` accepts exactly three things: a series rollup from `dev/<series>`, an S1 hotfix, and repo
 plumbing that touches no theme source.


### PR DESCRIPTION
Follow-up to #57, closing a gap that two live agent worktrees exposed within the hour.

## The gap

`Base Branch Guard` only matched `sprint/*`. But sprint work does not reliably live on `sprint/*` branches — agent worktrees produce names nothing anticipates:

| Branch | Carries Sprint 2 theme source? | Old guard |
|---|---|---|
| `name-change` | yes (`screen.css`, `index-luminous.hbs`, `partials/`) | **passes** |
| `worktree/brave-cloud-8ac8` | yes | **passes** |

`name-change` had already opened a PR. Either could have merged to `main` and deployed a partial Luminous series.

## The fix

Decision order:

| # | Condition | Result |
|---|---|---|
| 1 | `base-guard-override` label | pass |
| 2 | head is `dev/**` or `hotfix/*` | pass |
| 3 | head is `sprint/*` | fail |
| 4 | PR changes `assets/`, `partials/`, or `*.hbs` | fail |
| 5 | otherwise | pass |

Rule 4 is the real one: plumbing never touches theme source, a partial series always does. Rules 2–3 are cheap short-circuits — in particular `dev/**` is checked *before* the file listing so a whole-series rollup PR never enumerates thousands of files.

Verified against the full decision table locally; `dev/luminous`, `hotfix/*`, and docs-only branches all pass, `name-change` with `partials/*.hbs` fails, override passes.

Also documents a real footgun: adding the override label and hitting **re-run** does not work — a re-run replays the original event payload and cannot see the new label. Push a commit or reopen.

## Verification

**This PR is the negative test for rule 5**: `branch-protections` → `main` touches only `.github/` and `docs/`, so `Base Branch Guard` must be **green**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)