### PR TITLE
docs: wc-theme-qa loads now — correct BRANCHING.md

### DIFF
--- a/docs/BRANCHING.md
+++ b/docs/BRANCHING.md
@@ -180,25 +180,21 @@ Two things that bite:
   **invisible** to the dev instance — those directories are not synced. Push it and land it in
   the dev branch to see it live.
 
-### The `wc-theme-qa` skill loads, but not durably
+### Confirm the `wc-theme-qa` skill loaded before recording the gate
 
 `CLAUDE.md` points agents at the `wc-theme-qa` skill before merging anything touching shared CSS,
-`partials/components/`, `audio-player.js`, or `--show-accent`. As of 2026-07-26 that skill
-**does load** — it landed mid-sprint and `~/.claude/skills/wc-theme-qa` resolves.
+`partials/components/`, `audio-player.js`, or `--show-accent`. It automates the mechanizable
+parts of `docs/luminous/cross-brand-qa-checklist.md` and reports what it did not cover.
 
-It is **not merged upstream**, though. The skill lives on an unmerged branch in `the-lodge`
-(`mriechers/the-lodge#478`), and `~/.claude/skills/wc-theme-qa` is a symlink into that checkout.
-It resolves only while that checkout is parked on a branch containing it — a branch switch over
-there removes the skill from every session, silently, with nothing in this repo changing.
-
-So confirm it before relying on it:
+`~/.claude/skills/wc-theme-qa` is a **symlink into the `the-lodge` checkout**, so it can fail to
+resolve for reasons nothing in this repo will signal. Confirm it before relying on it:
 
 ```bash
 ls ~/.claude/skills/wc-theme-qa/SKILL.md   # exists → it will load
 ```
 
-Until #478 merges, the skill is a convenience and `docs/luminous/cross-brand-qa-checklist.md` is
-the gate. Either way: **do not record the gate as satisfied unless checks actually ran** — a
+If it doesn't load, work the checklist by hand. Either way the checklist is the gate and the
+skill automates it — and **do not record the gate as satisfied unless checks actually ran.** A
 skill that failed to load is not a pass.
 
 ---

--- a/docs/BRANCHING.md
+++ b/docs/BRANCHING.md
@@ -180,16 +180,26 @@ Two things that bite:
   **invisible** to the dev instance — those directories are not synced. Push it and land it in
   the dev branch to see it live.
 
-### The `wc-theme-qa` skill is not available yet
+### The `wc-theme-qa` skill loads, but not durably
 
-`CLAUDE.md` instructs agents to run the `wc-theme-qa` skill before merging anything touching
-shared CSS, `partials/components/`, `audio-player.js`, or `--show-accent`. As of 2026-07-26 that
-skill **does not load** — `~/.claude/skills/wc-theme-qa` is a broken symlink, and its design
-(`docs/superpowers/specs/2026-07-25-wc-theme-qa-harness-design.md`) is still marked *pending
-implementation*.
+`CLAUDE.md` points agents at the `wc-theme-qa` skill before merging anything touching shared CSS,
+`partials/components/`, `audio-player.js`, or `--show-accent`. As of 2026-07-26 that skill
+**does load** — it landed mid-sprint and `~/.claude/skills/wc-theme-qa` resolves.
 
-Until it ships, that gate is the **manual** checklist at
-`docs/luminous/cross-brand-qa-checklist.md`. Do not treat the skill reference as a gate that ran.
+It is **not merged upstream**, though. The skill lives on an unmerged branch in `the-lodge`
+(`mriechers/the-lodge#478`), and `~/.claude/skills/wc-theme-qa` is a symlink into that checkout.
+It resolves only while that checkout is parked on a branch containing it — a branch switch over
+there removes the skill from every session, silently, with nothing in this repo changing.
+
+So confirm it before relying on it:
+
+```bash
+ls ~/.claude/skills/wc-theme-qa/SKILL.md   # exists → it will load
+```
+
+Until #478 merges, the skill is a convenience and `docs/luminous/cross-brand-qa-checklist.md` is
+the gate. Either way: **do not record the gate as satisfied unless checks actually ran** — a
+skill that failed to load is not a pass.
 
 ---
 


### PR DESCRIPTION
Companion to #63, on the other side of the same stale fact.

#57 recorded in `docs/BRANCHING.md` that the `wc-theme-qa` skill *"does not load — broken symlink… pending implementation."* That was accurate when written. It is now false: the QA agent landed the harness in `the-lodge` while this session was running, and `~/.claude/skills/wc-theme-qa` resolves (`SKILL.md`, `GOTCHAS.md`, `pages.json`).

## The replacement is not "it works now"

`mriechers/the-lodge#478` is **still open**. The skill sits on an unmerged branch, and `~/.claude/skills/wc-theme-qa` is a symlink into that checkout — it resolves only while `the-lodge` is parked on a branch containing it.

That is a **sharper** trap than a plainly-broken symlink: a broken link fails loudly and always. This fails *silently and intermittently*, triggered by a branch switch in a different repo, with nothing in this repo changing. An agent could reasonably record the QA gate as run on Tuesday and find the skill gone on Wednesday.

| | |
|---|---|
| Loads today | ✅ verified |
| Merged upstream | ❌ the-lodge#478 open |
| Survives a branch switch in `the-lodge` | ❌ no |

## What it says now

- The skill loads, prefer it, **but confirm first**: `ls ~/.claude/skills/wc-theme-qa/SKILL.md`
- Until #478 merges it is a convenience; `docs/luminous/cross-brand-qa-checklist.md` is the gate
- Unchanged and still the point: **a gate is only satisfied if checks actually ran**

## Why separate from #63

Same stale fact, two files, two branches — deliberately not one PR:

- `CLAUDE.md` diverges between `main` and `dev/luminous` (Sprint 2 edited it), so its fix belongs on `dev/luminous` → **#63**
- `docs/BRANCHING.md` diverges the other way — #61 rewrote its guard section on `main`, and `dev/luminous` predates that — so its fix belongs on `main` → **this PR**

Editing either file on the wrong side would conflict at rollup.

## Guard check

Docs-only, no theme source, so `Base Branch Guard` should pass via rule 5 — which is also a live exercise of the content rule #61 added.

🤖 Generated with [Claude Code](https://claude.com/claude-code)