### PR TITLE
chore: sync main into dev/luminous (CI + BRANCHING.md)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,26 +36,53 @@ jobs:
     name: Base Branch Guard
     if: github.base_ref == 'main'
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: read
 
     steps:
-      - name: Reject sprint branches targeting main
+      - name: Reject sprint work targeting main
         env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+          PR: ${{ github.event.pull_request.number }}
           HEAD_REF: ${{ github.head_ref }}
           # Escape hatch, evaluated inside the step rather than as a job-level `if`, so the
           # check still reports and cannot deadlock a locked-down main.
           OVERRIDE: ${{ contains(github.event.pull_request.labels.*.name, 'base-guard-override') }}
         run: |
+          RETARGET="Retarget with: gh pr edit $PR --base dev/<series>. See docs/BRANCHING.md. Override with the 'base-guard-override' label."
+
           if [ "$OVERRIDE" = "true" ]; then
             echo "::notice::'base-guard-override' label present — skipping base branch check."
             exit 0
           fi
 
+          # The two sanctioned ways into main. Checked first so a rollup PR never pays for
+          # the file listing below, which can be thousands of files for a whole series.
           case "$HEAD_REF" in
+            dev/*|hotfix/*)
+              echo "'$HEAD_REF' -> main is allowed (series rollup or hotfix)."
+              exit 0
+              ;;
             sprint/*)
-              msg="'$HEAD_REF' targets main. Sprint work merges into the series integration branch (dev/<series>), which then rolls up to main as one gated deploy. Retarget with: gh pr edit <n> --base dev/<series>. See docs/BRANCHING.md. Override with the 'base-guard-override' label."
-              echo "::error::$msg"
+              echo "::error::'$HEAD_REF' targets main. Sprint work merges into the series integration branch (dev/<series>), which then rolls up to main as one gated deploy. $RETARGET"
               exit 1
               ;;
           esac
 
-          echo "'$HEAD_REF' -> main is allowed (series rollup, hotfix, or repo plumbing)."
+          # Branch naming is not a reliable signal — agent worktrees produce names like
+          # 'name-change' or 'worktree/brave-cloud-8ac8' that no pattern anticipates. What
+          # actually distinguishes sprint work from repo plumbing is whether it carries theme
+          # source. Plumbing (docs, planning, CI) never does; a partial series always does.
+          THEME=$(gh api --paginate "repos/$REPO/pulls/$PR/files" --jq '.[].filename' \
+                  | grep -E '^(assets/|partials/)|\.hbs$' || true)
+
+          if [ -n "$THEME" ]; then
+            echo "::error::'$HEAD_REF' targets main and changes theme source, which would deploy a partial series. Land it in dev/<series> so the whole series ships together. $RETARGET"
+            echo "Theme files in this PR:"
+            echo "$THEME" | sed 's/^/  /' | head -30
+            exit 1
+          fi
+
+          echo "'$HEAD_REF' -> main touches no theme source — allowed (repo plumbing)."

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -2,6 +2,10 @@ name: Claude Code Review
 
 on:
   pull_request:
+    # main only. This Action and the local /pr-watch loop are two independent reviewers;
+    # running both everywhere doubles the noise on high-volume dev/** sprint PRs. Scope the
+    # Action to the branch that actually deploys, and leave dev/** to pr-watch.
+    branches: [main]
     types: [opened, synchronize, ready_for_review, reopened]
     # Optional: Only run on specific file changes
     # paths:
@@ -21,7 +25,11 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-      pull-requests: read
+      # write, not read: the reviewer's whole output is a PR comment. With `read` the job
+      # still runs the full review, still reports SUCCESS, and silently publishes nothing —
+      # a green check that means "the reviewer could not speak". #50 granted write to
+      # claude.yml (the @claude mention flow) but missed this workflow.
+      pull-requests: write
       issues: read
       id-token: write
 
@@ -39,7 +47,7 @@ jobs:
           plugin_marketplaces: 'https://github.com/anthropics/claude-code.git'
           plugins: 'code-review@claude-code-plugins'
           prompt: '/code-review:code-review ${{ github.repository }}/pull/${{ github.event.pull_request.number }}'
-          claude_args: '--model claude-sonnet-4-6'
+          claude_args: '--model claude-sonnet-5'
           # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
           # or https://code.claude.com/docs/en/cli-reference for available options
 

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -35,7 +35,7 @@ jobs:
         uses: anthropics/claude-code-action@v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
-          claude_args: '--model claude-sonnet-4-6'
+          claude_args: '--model claude-sonnet-5'
 
           # This is an optional setting that allows Claude to read CI results on PRs
           additional_permissions: |

--- a/docs/BRANCHING.md
+++ b/docs/BRANCHING.md
@@ -53,10 +53,26 @@ The `dev/**` glob is what CI and the branch-protection ruleset key on. A branch 
 
 ## Which base branch?
 
-**Sprint work targets `dev/<series>`. Never `main`.** This is enforced: a `sprint/*` branch
-opened against `main` fails the **Base Branch Guard** check in CI. The error names the fix
-(`gh pr edit <n> --base dev/<series>`). If you genuinely need the exception, add the
-`base-guard-override` label to the PR and re-run.
+**Sprint work targets `dev/<series>`. Never `main`.** This is enforced by the **Base Branch
+Guard** check, which is required on `main`. Its decision order:
+
+| # | Condition | Result |
+|---|---|---|
+| 1 | PR has the `base-guard-override` label | **pass** |
+| 2 | head is `dev/**` or `hotfix/*` | **pass** — series rollup or hotfix |
+| 3 | head is `sprint/*` | **fail** |
+| 4 | PR changes `assets/`, `partials/`, or any `*.hbs` | **fail** — that's a partial series |
+| 5 | otherwise | **pass** — repo plumbing |
+
+Rule 4 exists because **branch naming is not a reliable signal.** Agent worktrees produce names
+like `name-change` or `worktree/brave-cloud-8ac8` that no pattern anticipates, and a `sprint/*`
+deny-list alone would wave them straight into production. What actually separates sprint work
+from plumbing is whether it carries theme source: plumbing (docs, planning, CI) never does, a
+partial series always does.
+
+The error message names the fix (`gh pr edit <n> --base dev/<series>`). If you genuinely need the
+exception, add the `base-guard-override` label and re-trigger — note that a *re-run* replays the
+original event payload and won't see the new label, so push a commit or reopen the PR instead.
 
 `main` accepts exactly three things: a series rollup from `dev/<series>`, an S1 hotfix, and repo
 plumbing that touches no theme source.
@@ -164,16 +180,22 @@ Two things that bite:
   **invisible** to the dev instance — those directories are not synced. Push it and land it in
   the dev branch to see it live.
 
-### The `wc-theme-qa` skill is not available yet
+### Confirm the `wc-theme-qa` skill loaded before recording the gate
 
-`CLAUDE.md` instructs agents to run the `wc-theme-qa` skill before merging anything touching
-shared CSS, `partials/components/`, `audio-player.js`, or `--show-accent`. As of 2026-07-26 that
-skill **does not load** — `~/.claude/skills/wc-theme-qa` is a broken symlink, and its design
-(`docs/superpowers/specs/2026-07-25-wc-theme-qa-harness-design.md`) is still marked *pending
-implementation*.
+`CLAUDE.md` points agents at the `wc-theme-qa` skill before merging anything touching shared CSS,
+`partials/components/`, `audio-player.js`, or `--show-accent`. It automates the mechanizable
+parts of `docs/luminous/cross-brand-qa-checklist.md` and reports what it did not cover.
 
-Until it ships, that gate is the **manual** checklist at
-`docs/luminous/cross-brand-qa-checklist.md`. Do not treat the skill reference as a gate that ran.
+`~/.claude/skills/wc-theme-qa` is a **symlink into the `the-lodge` checkout**, so it can fail to
+resolve for reasons nothing in this repo will signal. Confirm it before relying on it:
+
+```bash
+ls ~/.claude/skills/wc-theme-qa/SKILL.md   # exists → it will load
+```
+
+If it doesn't load, work the checklist by hand. Either way the checklist is the gate and the
+skill automates it — and **do not record the gate as satisfied unless checks actually ran.** A
+skill that failed to load is not a pass.
 
 ---
 


### PR DESCRIPTION
Brings `dev/luminous` up to `main` for the four files that have diverged since the series branched. No SHA rewriting.

## Why not just rebase `dev/luminous`

Rebasing is the textbook answer and it is wrong here — it would strand **four** branches currently sitting on the `dev/luminous` tip:

| branch | commits on dev/luminous |
|---|---|
| `name-change` (#60) | 14 |
| `fix/qa-gate-contradiction` (#63) | 4 |
| `sprint/3-impeccable-ux` | 2 |
| `worktree/brave-cloud-8ac8` | 2 |

All four were restacked earlier today; a rebase would force a second round for every one of them. It would also require temporarily lifting `non_fast_forward` on a protected branch. A forward-sync costs neither.

## What is out of date, and whether it matters

| File | Source | Actually broken today? |
|---|---|---|
| `docs/BRANCHING.md` | #61 + #65 | **Yes** — `dev/luminous`'s copy still says the `wc-theme-qa` skill "is not available yet", and still lacks the Base Branch Guard decision table. Sprint branches cut from here read it. |
| `.github/workflows/claude-code-review.yml` | #64 | **Yes** — without #64's `branches: [main]` scope, the reviewer still fires on `dev/**` PRs, which is the duplication #64 set out to stop |
| `.github/workflows/claude.yml` | #64 | Cosmetic — stale `claude-sonnet-4-6` model pin |
| `.github/workflows/ci.yml` | #61 | No — PRs into `dev/**` resolve `ci.yml` from their own merge ref and the guard job is `main`-only. Synced for consistency. |

## The rollup is unaffected — verified, not assumed

The obvious worry is that a commit duplicating `main`'s content will conflict when `dev/luminous` later rebase-merges into `main`. I simulated it rather than reasoning about it:

```
$ git rebase <main-with-#65>
dropping b47c6ebe … chore: sync main into dev/luminous -- patch contents already upstream
Successfully rebased and updated detached HEAD.

$ git log --oneline <main>..HEAD
a480d07d Sprint 2 — Brand Switch (#53)
89d2fdb4 Luminous Sprint 1 — multi-brand foundation & correctness (#46)
```

Git drops the sync commit automatically as already-applied. The rollup replays exactly the two sprint commits, as it would have without this PR.

## Source

All four files taken from the **#65 branch**, which is `main` + the `BRANCHING.md` correction — verified byte-identical to `main` for `.github/` (`git diff origin/main origin/docs/qa-skill-status -- .github/` is empty). Single source, so `dev/luminous` lands consistent with `main` whether #65 merges before or after this.

## Ordering

Independent of #63 — that PR touches `CLAUDE.md` and `cross-brand-qa-checklist.md`, this one touches `BRANCHING.md` and CI. No overlap, either order works.

🤖 Generated with [Claude Code](https://claude.com/claude-code)