### PR TITLE
Show blurbs read from the tag description, falling back to the site

### DIFF
--- a/index-luminous.hbs
+++ b/index-luminous.hbs
@@ -15,32 +15,10 @@
         {{!-- Podcast services: description slot + Luminous platform links (mirrors partials/podcast-services.hbs) --}}
         <section class="wc-podcast-services gh-outer">
             <div class="wc-podcast-services-inner gh-inner">
-                {{!-- Blurb comes from the tag:luminous description in Ghost — the same
-                     string that already serves as this page's meta description. Single
-                     source of truth; edit it in Ghost Admin, not here. Uses {{#get}}
-                     rather than the collection's `data: tag.luminous` binding so it does
-                     not depend on routes.yaml staying wired that way.
-
-                     Both failure modes fall back to @site.description so this slot can
-                     never silently empty: the tag going missing (outer {{else}}) and the
-                     tag existing with a blank description (inner {{else}}). The fallback
-                     is deliberately another editable Ghost field rather than hardcoded
-                     copy — copy duplicated here would only render when something is
-                     already broken, which is exactly when nobody would notice it had gone
-                     stale. Caveat: @site.description is currently Wonder Cabinet's blurb,
-                     so a Luminous page in fallback shows the network's copy, not the
-                     show's. Degraded mode, not the happy path. --}}
-                {{#get "tags" filter="slug:luminous" limit="1"}}
-                    {{#foreach tags}}
-                        {{#if description}}
-                            <p class="wc-podcast-services-desc">{{description}}</p>
-                        {{else}}
-                            <p class="wc-podcast-services-desc">{{@site.description}}</p>
-                        {{/if}}
-                    {{/foreach}}
-                {{else}}
-                    <p class="wc-podcast-services-desc">{{@site.description}}</p>
-                {{/get}}
+                {{!-- Blurb: tag:luminous description → @site.description. The resolution
+                     order and its rationale now live in components/show-blurb, shared with
+                     the Wonder Cabinet landing page. --}}
+                {{> "components/show-blurb" tagSlug="luminous"}}
                 <div class="wc-podcast-services-links">
                     {{#if @custom.luminous_apple_podcasts_link}}
                         <a href="{{@custom.luminous_apple_podcasts_link}}" target="_blank" rel="noopener noreferrer" class="wc-podcast-service" aria-label="Listen on Apple Podcasts">

--- a/partials/components/show-blurb.hbs
+++ b/partials/components/show-blurb.hbs
@@ -1,0 +1,36 @@
+{{!--
+    Show Blurb — the description slot for a show landing page.
+
+    Resolution order:
+      1. the show tag's `description` in Ghost   (Ghost Admin → Tags → <show>)
+      2. `@site.description`                     (Ghost Admin → Settings → General)
+
+    Both are editable Ghost fields on purpose. Hardcoded fallback copy would only ever
+    render when something is already broken — which is exactly when nobody would notice
+    it had gone stale.
+
+    Usage:
+        {{> "components/show-blurb" tagSlug="wonder-cabinet"}}
+        {{> "components/show-blurb" tagSlug="luminous"}}
+
+    Uses {{#get}} rather than the collection's `data: tag.<slug>` binding from
+    routes.yaml, so the slot does not depend on that staying wired. Both failure modes
+    fall through to @site.description and the slot can never silently empty: the tag
+    going missing (outer {{else}}) and the tag existing with a blank description
+    (inner {{else}}).
+
+    Caveat: @site.description is the *network's* blurb. A show page in fallback shows
+    the network's copy rather than the show's — degraded mode, not the happy path. Set
+    the show tag's description and the fallback never fires.
+--}}
+{{#get "tags" filter="slug:{{tagSlug}}" limit="1"}}
+    {{#foreach tags}}
+        {{#if description}}
+            <p class="wc-podcast-services-desc">{{description}}</p>
+        {{else}}
+            <p class="wc-podcast-services-desc">{{@site.description}}</p>
+        {{/if}}
+    {{/foreach}}
+{{else}}
+    <p class="wc-podcast-services-desc">{{@site.description}}</p>
+{{/get}}

--- a/partials/components/tag-header.hbs
+++ b/partials/components/tag-header.hbs
@@ -17,6 +17,22 @@
         <h1 class="wc-tag-hero-title">{{name}}</h1>
         {{#if description}}
             <p class="wc-tag-hero-description">{{description}}</p>
+        {{else}}
+            {{!-- Show tags — a tag that fronts its own podcast feed — fall back to the
+                 network blurb so a show page is never description-less. Ordinary tags stay
+                 silent on purpose: printing the network's podcast blurb under, say,
+                 "Island of Knowledge" would read as a mistake, not a fallback.
+
+                 routes.yaml's `collections:` is the source of truth for what counts as a
+                 show; keep this list in step when one is added.
+
+                 Currently unreachable, deliberately kept: routes.yaml claims both show tags
+                 for collections, so /tag/wonder-cabinet/ and /tag/luminous/ 301 to / and
+                 /luminous/ and never render this template. This is insurance for a show
+                 that has no collection, or for the routing changing. --}}
+            {{#has slug="wonder-cabinet, luminous"}}
+                <p class="wc-tag-hero-description">{{@site.description}}</p>
+            {{/has}}
         {{/if}}
     </div>
 </section>

--- a/partials/podcast-services.hbs
+++ b/partials/podcast-services.hbs
@@ -1,13 +1,15 @@
 {{!--
     Wonder Cabinet Podcast Services
-    Platform links with description
+    Platform links with description.
+
+    The blurb was hardcoded here until it moved to components/show-blurb, which reads the
+    `wonder-cabinet` tag description and falls back to @site.description. Both are editable
+    in Ghost Admin; neither is in this file. See show-blurb.hbs for the resolution order.
 --}}
 
 <section class="wc-podcast-services gh-outer">
     <div class="wc-podcast-services-inner gh-inner">
-        <p class="wc-podcast-services-desc">
-            Intimate conversations about the mysteries of the cosmos and life on a sentient planet with writers, philosophers and scientists who are dazzled by it all.
-        </p>
+        {{> "components/show-blurb" tagSlug="wonder-cabinet"}}
         <div class="wc-podcast-services-links">
             {{#if @custom.apple_podcasts_link}}
                 <a href="{{@custom.apple_podcasts_link}}" target="_blank" rel="noopener noreferrer" class="wc-podcast-service" aria-label="Listen on Apple Podcasts">


### PR DESCRIPTION
## What

Generalizes the pattern `index-luminous.hbs` already used, so every show landing page resolves its blurb the same way and a future show needs no template change.

New `partials/components/show-blurb.hbs`: **show tag `description` → `@site.description`**. Called with a slug —

```hbs
{{> "components/show-blurb" tagSlug="wonder-cabinet"}}
{{> "components/show-blurb" tagSlug="luminous"}}
```

| File | Change |
|---|---|
| `partials/podcast-services.hbs` | WC blurb was **hardcoded in the template** — now reads from Ghost, like Luminous already did |
| `index-luminous.hbs` | drops its inlined copy of the same logic |
| `partials/components/tag-header.hbs` | show tags fall back to the network blurb; ordinary tags keep hide-when-empty |

The fallback is deliberately another editable Ghost field rather than hardcoded copy: copy duplicated in a template only renders when something is already broken, which is exactly when nobody notices it has gone stale. Kept `{{#get}}` over routes.yaml's `data: tag.<slug>` binding so the slot doesn't depend on that staying wired — carried over from the Luminous original.

## ⚠️ Do not merge until the Ghost Admin edit lands

**This changes visible Wonder Cabinet homepage copy.** Ghost holds two different blurbs and the site was showing the site-level one while a tag-level one existed:

| Source | Text |
|---|---|
| Before — hardcoded, identical to `@site.description` | *"Intimate conversations about the mysteries of the cosmos and life on a sentient planet with writers, philosophers and scientists who are dazzled by it all."* |
| After — `wonder-cabinet` **tag** description | *"A new podcast from the people behind "To The Best Of Our Knowledge.""* |

Tag wins, by design. The agreed resolution is to update the **`wonder-cabinet` tag description in Ghost Admin → Tags** to the "Intimate conversations…" copy, which makes this a true WC visual no-op. Until that edit, §A of the cross-brand checklist will legitimately fail — that's a real difference, not a false positive.

`wc-theme-qa` should therefore run **after** the Admin edit, not before. This PR touches `partials/components/`, so that gate applies at merge.

Luminous is unaffected — it already resolved from `tag:luminous` and still renders *"In "Luminous," TTBOOK executive producer Steve Paulson explores the philosophical and cultural implications of psychedelics…"*

## On the tag-archive fallback — honest note

The show-tag branch in `tag-header.hbs` is **currently unreachable**, and I left it in deliberately with a comment saying so. `routes.yaml` claims both show tags for collections, so `/tag/wonder-cabinet/` 301s to `/` and `/tag/luminous/` to `/luminous/`; neither ever renders that template. It's insurance for a show without a collection, or for the routing changing. Flagging it rather than letting it read as active behaviour.

## Verification

- Staging: both landings render, no Ghost render errors
- `/tag/island-of-knowledge/` → 200, description slot still correctly silent (that tag has no description) — ordinary-tag behaviour unchanged
- `npx --yes gscan@5.2.4 .` on the CT → **compatible with Ghost 6.x** (pinned version per CLAUDE.md; `--no-install` would have resolved a stale 3.3.1)

## Separate bug found, not fixed here

`partials/components/series-info.hbs` gates on `{{#match slug "=" "luminous"}}` but then renders **Wonder Cabinet's** platform links (`@custom.apple_podcasts_link`, `spotify_link`, `youtube_music_link`) rather than the `luminous_*` ones. It's dead today for the same redirect reason, so nothing is broken in production — but unwire the `/luminous/` collection and Luminous pages would serve Wonder Cabinet feeds. Left out of this PR to keep the diff to the blurb work; worth its own issue.