### PR TITLE
Retire 5 custom settings; fix empty img src on tag pages

### DIFF
--- a/default.hbs
+++ b/default.hbs
@@ -24,9 +24,6 @@
             /* Literal fallback is load-bearing: the inline script below parses this value
                as a hex string, so it must never resolve empty if --wc-black is renamed. */
             --background-color: var(--wc-black, #000000);
-            {{#if @custom.galaxy_background_image}}
-            --wc-galaxy-bg: url({{@custom.galaxy_background_image}});
-            {{/if}}
         }
     </style>
 

--- a/package.json
+++ b/package.json
@@ -100,10 +100,6 @@
                 "type": "text",
                 "default": ""
             },
-            "linkedin_link": {
-                "type": "text",
-                "default": ""
-            },
             "tiktok_link": {
                 "type": "text",
                 "default": ""
@@ -112,28 +108,11 @@
                 "type": "text",
                 "default": ""
             },
-            "mastodon_link": {
-                "type": "text",
-                "default": ""
-            },
-            "email_link": {
-                "type": "text",
-                "default": "",
-                "description": "Contact email address (just the email, no mailto:)"
-            },
             "hero_tagline": {
                 "type": "text",
                 "default": "From the creators of <em>To The Best Of Our Knowledge</em>",
                 "description": "Homepage hero tagline. Renders as raw HTML — not escaped or filtered.",
                 "group": "homepage"
-            },
-            "hero_title_image": {
-                "type": "image",
-                "description": "Wonder Cabinet title graphic for homepage hero"
-            },
-            "galaxy_background_image": {
-                "type": "image",
-                "description": "Galaxy spiral background image for hero sections"
             }
         }
     },

--- a/partials/components/home-hero.hbs
+++ b/partials/components/home-hero.hbs
@@ -7,7 +7,7 @@
 <section class="wc-hero">
     <div class="wc-hero-content gh-inner">
         <span class="wc-hero-welcome">Welcome to</span>
-        <img src="{{@custom.hero_title_image}}" alt="Wonder Cabinet" class="wc-hero-title">
+        <img src="{{asset "images/WonderCabinet-title.webp"}}" alt="Wonder Cabinet" class="wc-hero-title">
         {{!-- Tagline is editable in Ghost Admin → Design (custom.hero_tagline).
              Triple-stache is deliberate: the field carries <em> around the show
              title, and Ghost custom settings have no rich-text type. Only

--- a/partials/components/navbar.hbs
+++ b/partials/components/navbar.hbs
@@ -14,7 +14,11 @@
              Luminous a violet-cabinet variant (CSS-toggled by brand) so it shows on the
              dark nav and matches the violet scheme instead of clashing with green. --}}
         <a class="gh-head-logo wc-head-logo" href="/">
-            <img class="wc-head-logo-img wc-head-logo-img--default" src="{{@site.logo}}" alt="{{@site.title}}">
+            {{!-- Falls back to the bundled logo so clearing the Ghost site logo can never
+                 emit src="" on every page — an empty src resolves to the document URL and
+                 makes the browser re-request the page. The bundled file is a larger,
+                 unoptimised copy, so this is a working degraded state, not a match. --}}
+            <img class="wc-head-logo-img wc-head-logo-img--default" src="{{#if @site.logo}}{{@site.logo}}{{else}}{{asset "images/logo-primary-dark-bg-800w.webp"}}{{/if}}" alt="{{@site.title}}">
             <img class="wc-head-logo-img wc-head-logo-img--luminous" src="{{asset "images/logo-cabinet-violet-800.png"}}" alt="{{@site.title}}">
         </a>
 

--- a/partials/components/social-links.hbs
+++ b/partials/components/social-links.hbs
@@ -33,12 +33,6 @@
         </a>
     {{/if}}
 
-    {{#if @custom.linkedin_link}}
-        <a href="{{@custom.linkedin_link}}" target="_blank" rel="noopener noreferrer" aria-label="LinkedIn">
-            {{> "icons/linkedin"}}
-        </a>
-    {{/if}}
-
     {{#if @custom.tiktok_link}}
         <a href="{{@custom.tiktok_link}}" target="_blank" rel="noopener noreferrer" aria-label="TikTok">
             {{> "icons/tiktok"}}
@@ -51,16 +45,6 @@
         </a>
     {{/if}}
 
-    {{#if @custom.mastodon_link}}
-        <a href="{{@custom.mastodon_link}}" target="_blank" rel="noopener noreferrer" aria-label="Mastodon">
-            {{> "icons/mastodon"}}
-        </a>
-    {{/if}}
-
-    {{!-- Email contact link --}}
-    {{#if @custom.email_link}}
-        <a href="mailto:{{@custom.email_link}}" aria-label="Email">
-            {{> "icons/email"}}
-        </a>
-    {{/if}}
+    {{!-- Mastodon and email were retired: Mastodon was never used, and the email link was
+         superseded by the contact page. LinkedIn removed above for the same reason. --}}
 </div>

--- a/partials/components/tag-header.hbs
+++ b/partials/components/tag-header.hbs
@@ -6,7 +6,7 @@
 
 <section class="wc-tag-hero{{#if feature_image}} has-feature-image{{/if}}">
     <div class="wc-tag-hero-bg">
-        <img src="{{@custom.galaxy_background_image}}" alt="" class="wc-tag-hero-galaxy" aria-hidden="true">
+        <img src="{{asset "images/bg-galaxy-spiral-1200w-2x.webp"}}" alt="" class="wc-tag-hero-galaxy" aria-hidden="true">
     </div>
     <div class="wc-tag-hero-content gh-inner">
         {{#if feature_image}}


### PR DESCRIPTION
## Why

The theme was at **20/20 custom settings — Ghost's hard cap** — which blocks adding a third show (Apple + Spotify + YouTube + tagline = 4 settings). This frees 5.

| | Settings |
|---|---|
| before | 20 / 20 |
| after | **15 / 20** |

## What was retired

**Dead by content — nothing rendering:**
- `mastodon_link` — never used
- `email_link` — superseded by the contact page
- `linkedin_link` — unset

**Holdovers from the forked Episode theme.** Both pointed at Ghost uploads that are **byte-identical to assets already bundled in the theme**:

```
galaxy   uploaded 442746 B  md5 19ef10b17c19734525a08bfab73299f6
         bundled  442746 B  md5 19ef10b17c19734525a08bfab73299f6   ← same file

title    uploaded  23848 B  md5 b5be49a6b02855ede984c20ee7777a8b
         bundled   23848 B  md5 b5be49a6b02855ede984c20ee7777a8b   ← same file
```

Somebody had uploaded the theme's own assets back into Ghost. Templates now reference the bundled files directly, so this is pixel-for-pixel identical — provable, not asserted.

The reasoning for keeping graphics out of Admin: they change rarely and never without the site owner, unlike taglines and links. This theme is far enough from the forked Episode base that these were holdovers rather than features.

**`threads_link` deliberately kept** — it's live at `@wondercabinetpod`, one of only four populated social links.

## Bug this exposed

`tag-header.hbs` rendered the galaxy as a **bare** `<img src="{{@custom.galaxy_background_image}}">`. When the setting was cleared on dev, every tag and newsletter archive shipped:

```html
<img src="" alt="" class="wc-tag-hero-galaxy" aria-hidden="true">
```

Decorative and `aria-hidden`, so nothing *looked* wrong — but an empty `src` resolves to the document's own URL, so browsers re-request the page on every view. `home-hero.hbs` had the same unguarded shape for the title graphic.

I audited every `<img>` in the theme and found a third: **`navbar.hbs` renders `<img src="{{@site.logo}}">` unguarded, on every page.** It's populated today, but clearing Ghost's site logo would put `src=""` sitewide. Now guarded — `@site.logo` stays the source (a Ghost *core* field, not part of the 20-cap), it just falls back to the bundled logo. That bundled file is a larger unoptimised copy (87,502 B vs the uploaded 60,042 B), so the fallback is a **working degraded state, not a pixel match** — worth knowing before anyone relies on it.

Everything else resolves through `{{asset}}` or is already `{{#if}}`-guarded.

## Verification (staging)

- `/tag/island-of-knowledge/` galaxy → `200`, **442,746 B** — the md5-identical file
- Homepage hero title → `200`, **23,848 B** — likewise
- Social icons still render Bluesky / Facebook / Instagram / **Threads**
- `/luminous/` `200`, hero assets untouched
- `npx --yes gscan@5.2.4 .` on the CT → compatible with Ghost 6.x

## Scope note

Five free slots covers **one** more show, with one spare. Show #4 hits the cap again, because platform links are still 3-per-show. The deeper fix — per-show config from a single source instead of triplicated across `brand.json`, theme settings, and the tag description — is deliberately deferred until a third show is actually real.

Stacks cleanly with #78 (show blurbs from the tag description); no overlapping files.